### PR TITLE
Fix incorrect usage of MaybeUninit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -850,11 +850,11 @@ macro_rules! make_direction_table {
         impl<T> $table_type<T> {
             pub fn new_fn<F: FnMut($direction_type) -> T>(mut f: F) -> Self {
                 let values = unsafe {
-                    let mut values: [T; $count] = MaybeUninit::uninit().assume_init();
+                    let mut values: [MaybeUninit<T>; $count] = MaybeUninit::uninit().assume_init();
                     for i in 0..$count {
-                        values[i] = f(mem::transmute(i as u8));
+                        values[i].write(f(mem::transmute(i as u8)));
                     }
-                    values
+                    mem::transmute_copy::<[MaybeUninit<T>; $count], [T; $count]>(&values)
                 };
                 Self { values }
             }


### PR DESCRIPTION
Running the tests of this repo under [miri](https://github.com/rust-lang/miri) reports Undefined Behavior because of incorrect use of `MaybeUninit`:
```rs
error: Undefined Behavior: constructing invalid value at .value[0].<enum-tag>: encountered uninitialized bytes, but expected initialized bytes
   --> src/lib.rs:853:51
    |
853 |                       let mut values: [T; $count] = MaybeUninit::uninit().assume_init();
    |                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .value[0].<enum-tag>: encountered uninitialized bytes, but expected initialized bytes
```

`T` is not permitted to be uninitialized and yet uninitialized `T`s are created. The fix is to keep the uninitialized `T`s wrapped in `MaybeUninit` during lazy initialization in the loop (then they are permitted to be uninitialized) and only actually transmute the `[MaybeUninit<T>; $count]` when all `T`s are fully initialized (after the loop).